### PR TITLE
[SDPA-4582] Added display headings field and updated label for show t…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^1.2.6",
+        "dpc-sdp/tide_core": "dev-feature/SDPA-4582-display-h3-headings as 1.6.9",
         "dpc-sdp/tide_media": "^1.2.6"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SDPA-4582-display-h3-headings as 1.6.9",
+        "dpc-sdp/tide_core": "^1.6.11",
         "dpc-sdp/tide_media": "^1.2.6"
     },
     "suggest": {

--- a/config/install/core.entity_form_display.node.page.default.yml
+++ b/config/install/core.entity_form_display.node.page.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.page.field_featured_image
     - field.field.node.page.field_graphical_image
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_node_display_headings
     - field.field.node.page.field_page_intro_text
     - field.field.node.page.field_related_links
     - field.field.node.page.field_show_related_content
@@ -79,6 +80,7 @@ third_party_settings:
         - field_show_social_sharing
         - field_show_content_rating
         - field_show_table_of_content
+        - field_node_display_headings
       parent_name: group_right_column
       weight: 8
       format_type: tab
@@ -145,6 +147,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
+    region: content
+  field_node_display_headings:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
     region: content
   field_page_intro_text:
     weight: 3

--- a/config/install/field.field.node.page.field_node_display_headings.yml
+++ b/config/install/field.field.node.page.field_node_display_headings.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_node_display_headings
+    - node.type.page
+  module:
+    - options
+id: node.page.field_node_display_headings
+field_name: field_node_display_headings
+entity_type: node
+bundle: page
+label: 'Display headings'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: showH2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.node.page.field_show_table_of_content.yml
+++ b/config/install/field.field.node.page.field_show_table_of_content.yml
@@ -9,7 +9,7 @@ field_name: field_show_table_of_content
 entity_type: node
 bundle: page
 label: 'Show Table of Content?'
-description: 'Check this box if you want to show the Table of Content on this page.'
+description: 'The table of contents is automatically built from the heading structure of your page.'
 required: false
 translatable: false
 default_value:

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.node--page.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.node--page.yml
@@ -212,6 +212,12 @@ resourceFields:
     disabled: false
     advancedOptionsIcon: ''
     enhancer_label: ''
+  field_node_display_headings:
+    fieldName: field_node_display_headings
+    publicName: field_node_display_headings
+    enhancer:
+      id: ''
+    disabled: false
   field_page_intro_text:
     fieldName: field_page_intro_text
     publicName: field_page_intro_text

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -52,6 +52,11 @@ Feature: Fields for Page content type
     And I should see an "input#edit-field-show-table-of-content-value" element
     And I should not see an "input#edit-field-show-table-of-content.required" element
 
+    When I check "edit-field-show-table-of-content-value"
+    Then I should see text matching "Display headings"
+    And I should see an "input#edit-field-node-display-headings-showh2" element
+    And I should see an "input#edit-field-node-display-headings-showh2andh3" element
+
     And I see field "Show topic term and tags?"
     And I should see an "input#edit-field-show-topic-term-and-tags-value" element
     And I should not see an "input#edit-field-show-topic-term-and-tags-value.required" element
@@ -109,6 +114,11 @@ Feature: Fields for Page content type
     And I see field "Show Table of Content?"
     And I should see an "input#edit-field-show-table-of-content-value" element
     And I should not see an "input#edit-field-show-table-of-content.required" element
+
+    When I check "edit-field-show-table-of-content-value"
+    Then I should see text matching "Display headings"
+    And I should see an "input#edit-field-node-display-headings-showh2" element
+    And I should see an "input#edit-field-node-display-headings-showh2andh3" element
 
     And I see field "Show topic term and tags?"
     And I should see an "input#edit-field-show-topic-term-and-tags-value" element

--- a/tide_page.info.yml
+++ b/tide_page.info.yml
@@ -27,6 +27,7 @@ config_devel:
     - field.field.node.page.body
     - field.field.node.page.field_featured_image
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_node_display_headings
     - field.field.node.page.field_page_intro_text
     - field.field.node.page.field_show_topic_term_and_tags
     - field.field.node.page.field_whats_next

--- a/tide_page.install
+++ b/tide_page.install
@@ -202,3 +202,77 @@ function tide_page_update_8005() {
     }
   }
 }
+
+/**
+ * Add field display headings for table of contents.
+ */
+function tide_page_update_8006() {
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_page') . '/config/install'];
+  $new_field = 'field.field.node.page.field_node_display_headings';
+  $config_read = _tide_read_config($new_field, $config_location, TRUE);
+  // Obtain the storage manager for field instances.
+  // Create a new field instance from the yaml configuration and save.
+  \Drupal::entityManager()->getStorage('field_config')
+    ->create($config_read)
+    ->save();
+
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('core.entity_form_display.node.page.default');
+
+  $dependencies = $config->get('dependencies.config');
+  if (!in_array('field.field.node.page.field_node_display_headings', $dependencies)) {
+    $dependencies[] = 'field.field.node.page.field_node_display_headings';
+    $config->set('dependencies.config', $dependencies);
+  }
+
+  $third_party_settings = $config->get('third_party_settings.field_group.group_other.children');
+  if (!isset($third_party_settings['field_node_display_headings'])) {
+    $third_party_settings = [
+      'field_show_social_sharing',
+      'field_show_content_rating',
+      'field_show_table_of_content',
+      'field_node_display_headings',
+    ];
+    $config->set('third_party_settings.field_group.group_other.children', $third_party_settings);
+  }
+  $table_of_content_weight = $config->get('content.field_show_table_of_content.weight');
+  $content = $config->get('content');
+  if (!isset($content['field_node_display_headings'])) {
+    $content['field_node_display_headings'] = [
+      'weight' => $table_of_content_weight + 1,
+      'settings' => [],
+      'third_party_settings' => [],
+      'type' => 'options_buttons',
+      'region' => 'content',
+    ];
+    $config->set('content', $content);
+  }
+
+  $config->save();
+
+  // Add to JSON
+  $json_config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.node--page');
+
+  $json_content = $json_config->get('resourceFields');
+  if (!isset($json_content['field_node_display_headings'])) {
+    $json_content['field_node_display_headings'] = [
+      'fieldName' => 'field_node_display_headings',
+      'publicName' => 'field_node_display_headings',
+      'enhancer' => [
+        'id' => '',
+      ],
+      'disabled' => FALSE,
+    ];
+
+    $json_config->set('resourceFields', $json_content);
+  }
+
+  $config->save();
+
+  // Update show table of content label.
+  $field_config = $config_factory->getEditable('field.field.node.page.field_show_table_of_content');
+  $description = 'The table of contents is automatically built from the heading structure of your page.';
+  $field_config->set('description', $description);
+  $field_config->save();
+}

--- a/tide_page.install
+++ b/tide_page.install
@@ -270,7 +270,7 @@ function tide_page_update_8006() {
     $json_config->set('resourceFields', $json_content);
   }
 
-  $config->save();
+  $json_config->save();
 
   // Update show table of content label.
   $field_config = $config_factory->getEditable('field.field.node.page.field_show_table_of_content');

--- a/tide_page.install
+++ b/tide_page.install
@@ -53,6 +53,8 @@ function tide_page_install() {
 function tide_page_update_dependencies() {
   $dependencies['tide_page'][8001] = ['tide_core' => 8001];
   $dependencies['tide_page'][8002] = ['tide_core' => 8002];
+  $dependencies['tide_page'][8006] = ['tide_core' => 8036];
+
   return $dependencies;
 }
 
@@ -251,7 +253,7 @@ function tide_page_update_8006() {
 
   $config->save();
 
-  // Add to JSON
+  // Add to JSON.
   $json_config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.node--page');
 
   $json_content = $json_config->get('resourceFields');

--- a/tide_page.install
+++ b/tide_page.install
@@ -53,7 +53,7 @@ function tide_page_install() {
 function tide_page_update_dependencies() {
   $dependencies['tide_page'][8001] = ['tide_core' => 8001];
   $dependencies['tide_page'][8002] = ['tide_core' => 8002];
-  $dependencies['tide_page'][8006] = ['tide_core' => 8036];
+  $dependencies['tide_page'][8006] = ['tide_core' => 8037];
 
   return $dependencies;
 }

--- a/tide_page.module
+++ b/tide_page.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Tide Page module functionality.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function tide_page_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (in_array($form_id, ['node_page_form', 'node_page_edit_form'])) {
+    // Add conditional field for show table of content.
+    if (isset($form['field_node_display_headings'])) {
+      $form['field_node_display_headings']['#states'] = [
+        'visible' => [
+          ':input[name="field_show_table_of_content[value]"]' => [
+            'checked' => TRUE
+          ],
+        ],
+      ];
+    }
+  }
+}

--- a/tide_page.module
+++ b/tide_page.module
@@ -17,7 +17,7 @@ function tide_page_form_node_form_alter(&$form, FormStateInterface $form_state, 
       $form['field_node_display_headings']['#states'] = [
         'visible' => [
           ':input[name="field_show_table_of_content[value]"]' => [
-            'checked' => TRUE
+            'checked' => TRUE,
           ],
         ],
       ];


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4582

### Change
1. Added new field instance for the header radio button (Which will be used to show H2 or H2 and H3 for table of contents.) on and update hook.
2. Update entity form display and Json resource.
3. Updated help text for "show table of contents" checkbox.
4. **Added tide_page module to add module functionality**. Conditional filed logic in node_form_alter to show the new field only when the "show table of contents" checkbox is checked.
5. Added behat test.

### Related PR
Field storage added in tide_core - https://github.com/dpc-sdp/tide_core/pull/175
https://github.com/dpc-sdp/tide_landing_page/pull/106
https://github.com/dpc-sdp/tide_publication/pull/11

### Test branch on content-vic
https://github.com/dpc-sdp/content-vic-gov-au/pull/963